### PR TITLE
Autoload with classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
         "masterminds/html5": "^2.1"
     },
     "autoload": {
-        "files": [
-            "inc/class-unholy-testcase.php"
+        "classmap": [
+            "inc/"
         ]
     },
     "license": "MIT",

--- a/inc/class-unholy-testcase.php
+++ b/inc/class-unholy-testcase.php
@@ -2,7 +2,7 @@
 
 use Masterminds\HTML5;
 
-class Unholy_Testcase extends WP_UnitTestcase {
+abstract class Unholy_Testcase extends WP_UnitTestcase {
 
 	public function setUp() {
 		parent::setUp();


### PR DESCRIPTION
This PR changes the autoloader to use the deferred `classmap` lazy-loading method rather than loading the Unholy TestCase for every request which can sometimes cause problems.
