### PR TITLE
Output handling

### DIFF
--- a/inc/class-unholy-testcase.php
+++ b/inc/class-unholy-testcase.php
@@ -14,8 +14,7 @@ abstract class Unholy_Testcase extends WP_UnitTestcase {
 		ob_start();
 		$this->go_to( $path );
 		$this->load_template();
-		$output = ob_get_contents();
-		ob_end_flush();
+		$output = ob_get_clean();
 
 		$html5 = new HTML5();
 		$dom = $html5->loadHTML($output);
@@ -27,8 +26,7 @@ abstract class Unholy_Testcase extends WP_UnitTestcase {
 		ob_start();
 		$this->go_to( $path );
 		@$this->do_feed();
-		$output = ob_get_contents();
-		ob_end_flush();
+		$output = ob_get_clean();
 
 		$doc = new DOMDocument;
 		$doc->loadXML( $output );

--- a/inc/class-unholy-testcase.php
+++ b/inc/class-unholy-testcase.php
@@ -8,9 +8,6 @@ abstract class Unholy_Testcase extends WP_UnitTestcase {
 		parent::setUp();
 		$this->setup_permalink_structure();
 		$_SERVER['REQUEST_METHOD'] = 'GET';
-		$this->setOutputCallback( function() {
-			return '';
-		});
 	}
 
 	protected function get_permalink_as_dom( $path ) {


### PR DESCRIPTION
This PR cleans up the internal output buffering and removes the need to set the output callback on the test case.  Setting that callback creates a confusing situation where output during the test case is not shown at all, even if you are deliberately trying to for some reason.  This should be more consistent with what most people would expect.

See: [Difference between ob_get_clean and ob_get_flush](http://stackoverflow.com/a/7379814/1037938)
